### PR TITLE
Refactoring to fix use of paths

### DIFF
--- a/src/mise/analysisview/analysis_window.py
+++ b/src/mise/analysisview/analysis_window.py
@@ -118,9 +118,11 @@ class AnalysisView(QWidget):
         self.stacked.setCurrentIndex(self.PAGE_CODE_SEGMENTS)
 
     def _on_document_selected(self, text_path: str, doc_id: int):
-        text_path = Path(text_path)
+        # text_path is the DB value (now relative); resolve it to an absolute path
+        abs_path = (self.repo.texts_dir / text_path).resolve()
+
         self.show_document_page()
-        self.document_view.display_file_content(text_path)
+        self.document_view.display_file_content(abs_path)
         self.document_view.current_document_id = doc_id
         self.document_view.refresh_highlights()
 
@@ -128,11 +130,11 @@ class AnalysisView(QWidget):
         self.show_code_segments_page()
         self.code_segment_view.load_segments_for_code(code_id)
     
-    def _on_segment_activated(self, doc_id: int, start: int, end: int, text_path: str):
+    def _on_segment_activated(self, doc_id: int, start: int, end: int):
         # Switch to document page
         self.show_document_page()
+        path = self.repo.get_document_path(doc_id)
 
-        path = Path(text_path)
         self.document_view.display_file_content(path)
         self.document_view.current_document_id = doc_id
 

--- a/src/mise/app_controller.py
+++ b/src/mise/app_controller.py
@@ -43,13 +43,14 @@ class AppController:
         """
         project_root = init_project(project_name, str(base_dir))
         db_path = project_root / "project.db"
-        repo = ProjectRepository(db_path)
+        texts_dir = project_root / "texts"
+        repo = ProjectRepository(db_path, texts_dir)
         self._set_current_project(project_name, project_root, repo)
         self._create_project_view_if_needed()
         self.show_project_view()
         log.info("Project %s created at %r.", project_name, project_root)
 
-    def open_project(self, project_root: Path):
+    def open_project(self, project_root: Path, texts_dir: Path):
         """
         Open existing project, checking if .mise file in user selected directory.
         Switches to project view.
@@ -74,7 +75,7 @@ class AppController:
             project_name = project_name[:-5]
 
         db_path = project_root / "project.db"
-        repo = ProjectRepository(db_path)
+        repo = ProjectRepository(db_path, texts_dir)
 
         self._set_current_project(project_name, project_root, repo)
         self._create_project_view_if_needed()

--- a/src/mise/main_window.py
+++ b/src/mise/main_window.py
@@ -150,8 +150,9 @@ class MainWindow(QMainWindow):
             return  # user cancelled
 
         project_root = Path(dirpath_str)
+        print(project_root)
 
-        self.controller.open_project(project_root = project_root)
+        self.controller.open_project(project_root = project_root, texts_dir = project_root / "texts" )
 
     def _handle_show_about_dialog(self):
         QMessageBox.about(

--- a/src/mise/utils/import_service.py
+++ b/src/mise/utils/import_service.py
@@ -18,7 +18,7 @@ def import_files(src_paths: list[Path], texts_dir: Path, repo) -> tuple[bool, li
 
         try:
             text = convert_to_canonical_text(src_path)
-            dest_path = allocate_text_path(texts_dir)
+            dest_path = allocate_text_name(texts_dir)
             dest_path.write_text(text, encoding="utf-8")
             repo.register_document(src_path.name, dest_path)
             imported_any = True
@@ -27,7 +27,10 @@ def import_files(src_paths: list[Path], texts_dir: Path, repo) -> tuple[bool, li
 
     return imported_any, errors
 
-def allocate_text_path(texts_dir: Path) -> Path:
+def allocate_text_name(texts_dir: Path) -> Path:
     existing = list(texts_dir.glob("doc-*.txt"))
+    print(existing)
     next_id = len(existing) + 1
+
+    log.info("allocate_text_name: allocating %s", f"doc-{next_id:04d}.txt")
     return texts_dir / f"doc-{next_id:04d}.txt"


### PR DESCRIPTION
v0.1.0 was built with classes and methods using absolut paths to project files which is not a problem until the project directory moves and the text path stored in the database changes. A number of classes and methods used paths to pass information between them. I have refactored in a very fast and loose way to plug these issues but it will require a more substantial refactoring to change the architecture of Mise to rely upon the metadata stored in the database to return the relative path to text documents.